### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/j0rdsta/ha-desky/security/code-scanning/3](https://github.com/j0rdsta/ha-desky/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code, installs dependencies, runs tests, and uploads coverage (with no write operations to the repository), the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level. The best practice is to add it at the top level, just after the `name` field and before `on:`. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
