### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,4 +1,6 @@
 name: HACS Action
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/j0rdsta/ha-desky/security/code-scanning/2](https://github.com/j0rdsta/ha-desky/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply only to the `hacs` job). Since there is only one job in this workflow, adding it at the root is simplest and most maintainable. The minimal required permission for this workflow is `contents: read`, as none of the steps require write access. This change should be made at the top level of `.github/workflows/hacs.yaml`, immediately after the `name` field and before the `on` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
