### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,4 +1,6 @@
 name: Validate with hassfest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/j0rdsta/ha-desky/security/code-scanning/1](https://github.com/j0rdsta/ha-desky/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, since the workflow only checks out code and runs a validation action, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the top level of the workflow (applies to all jobs), specifying `contents: read`. This should be added after the `name` field and before the `on` field in `.github/workflows/hassfest.yaml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
